### PR TITLE
fix: ANLSPI-26449 move to Xcode 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
   
-    runs-on: macos-latest
+    runs-on: macos-15
     
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://developer.apple.com/news/?id=9s0rgdy9

Beginning April 24, 2025, apps uploaded to App Store Connect must be built with Xcode 16 or later using an SDK for iOS 18, iPadOS 18, tvOS 18, visionOS 2, or watchOS 11.